### PR TITLE
GET

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,20 @@
+// Example Application for Frame.io's custom action feature.  
+
 const express = require('express');
 const bodyParser = require('body-parser');
 const app = express();
 const port = process.env.PORT || 3000;
 
 app.use(bodyParser.json());
+
+// GET is not used with custom actions, but tools like Glitch or Postman are often set to try a GET request.
+// This is provided so you don't receive a 'Can't GET' notification.
+
+app.get('/', function (req, res) {
+  res.end('Hello World');
+});
+
+// Send a POST request to /actions to create a form in the Frame.io web app
 
 app.post('/actions', function (req, res) {
   if (req.body.data) {


### PR DESCRIPTION
A lot of testing tools start up by trying a GET request. If a GET isn't included then it'll give an error. The GET is added for best practices. (And yes some situations the GET doesn't happen, but it would for Postman or Glitch.)